### PR TITLE
Add horizontally scrolling bento grid demo

### DIFF
--- a/app/bento-demo/page.tsx
+++ b/app/bento-demo/page.tsx
@@ -1,0 +1,63 @@
+import { BentoGridProvider, BentoGrid, BentoBox, useBentoGrid } from "@/components/scroll-bento"
+import {
+  SidebarProvider,
+  Sidebar,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+} from "@/components/ui/sidebar"
+
+function DemoSidebar({ count }: { count: number }) {
+  const { scrollTo } = useBentoGrid()
+  return (
+    <Sidebar className="p-2">
+      <SidebarMenu>
+        {Array.from({ length: count }, (_, i) => (
+          <SidebarMenuItem key={i}>
+            <SidebarMenuButton onClick={() => scrollTo(String(i + 1))}>
+              {i + 1}
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ))}
+      </SidebarMenu>
+    </Sidebar>
+  )
+}
+
+export default function BentoDemoPage() {
+  const boxes = Array.from({ length: 25 }, (_, i) => ({ id: String(i + 1) }))
+  const colors = [
+    "bg-red-300",
+    "bg-blue-300",
+    "bg-green-300",
+    "bg-yellow-300",
+    "bg-purple-300",
+    "bg-pink-300",
+    "bg-orange-300",
+  ]
+
+  return (
+    <BentoGridProvider>
+      <SidebarProvider defaultOpen>
+        <div className="flex h-svh">
+          <DemoSidebar count={boxes.length} />
+          <div className="flex-1 overflow-hidden p-4">
+            <BentoGrid rows={4} className="h-full min-w-max" style={{ scrollSnapType: "x mandatory" }}>
+              {boxes.map((box, idx) => (
+                <BentoBox
+                  key={box.id}
+                  id={box.id}
+                  rowSpan={(idx % 3) + 1}
+                  colSpan={idx % 2 === 0 ? 2 : 1}
+                  className={`${colors[idx % colors.length]} flex items-center justify-center rounded-md text-xl font-bold min-w-32 min-h-20`}
+                >
+                  {box.id}
+                </BentoBox>
+              ))}
+            </BentoGrid>
+          </div>
+        </div>
+      </SidebarProvider>
+    </BentoGridProvider>
+  )
+}

--- a/components/scroll-bento/bento-grid.tsx
+++ b/components/scroll-bento/bento-grid.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export type BentoGridContextValue = {
+  register: (id: string, el: HTMLElement | null) => void
+  scrollTo: (id: string) => void
+  containerRef: React.RefObject<HTMLDivElement>
+}
+
+const BentoGridContext = React.createContext<BentoGridContextValue | null>(null)
+
+export function useBentoGrid() {
+  const ctx = React.useContext(BentoGridContext)
+  if (!ctx) {
+    throw new Error("useBentoGrid must be used within BentoGridProvider")
+  }
+  return ctx
+}
+
+interface BentoGridProviderProps {
+  children: React.ReactNode
+}
+
+function BentoGridProvider({ children }: BentoGridProviderProps) {
+  const containerRef = React.useRef<HTMLDivElement>(null)
+  const itemsRef = React.useRef(new Map<string, HTMLElement>())
+
+  const register = React.useCallback((id: string, el: HTMLElement | null) => {
+    if (el) itemsRef.current.set(id, el)
+    else itemsRef.current.delete(id)
+  }, [])
+
+  const scrollTo = React.useCallback((id: string) => {
+    const el = itemsRef.current.get(id)
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" })
+    }
+  }, [])
+
+  const value = React.useMemo(() => ({ register, scrollTo, containerRef }), [register, scrollTo])
+
+  return <BentoGridContext.Provider value={value}>{children}</BentoGridContext.Provider>
+}
+
+interface BentoGridProps extends React.HTMLAttributes<HTMLDivElement> {
+  rows?: number
+}
+
+function Grid({ rows = 3, className, style, children, ...props }: BentoGridProps) {
+  const { containerRef } = useBentoGrid()
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "grid overflow-x-auto scroll-smooth gap-4 [grid-auto-flow:column_dense]",
+        className
+      )}
+      style={{
+        gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))`,
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+interface BentoBoxProps extends React.HTMLAttributes<HTMLDivElement> {
+  id: string
+  rowSpan?: number
+  colSpan?: number
+}
+
+function BentoBox({ id, rowSpan = 1, colSpan = 1, className, style, ...props }: BentoBoxProps) {
+  const { register } = useBentoGrid()
+  const ref = React.useRef<HTMLDivElement>(null)
+
+  React.useEffect(() => {
+    register(id, ref.current)
+    return () => register(id, null)
+  }, [id, register])
+
+  return (
+    <div
+      ref={ref}
+      className={cn("scroll-m-4", className)}
+      style={{
+        gridRow: `span ${rowSpan} / span ${rowSpan}`,
+        gridColumn: `span ${colSpan} / span ${colSpan}`,
+        scrollSnapAlign: "start",
+        ...style,
+      }}
+      {...props}
+    />
+  )
+}
+
+export { BentoGridProvider, Grid as BentoGrid, BentoBox }

--- a/components/scroll-bento/index.ts
+++ b/components/scroll-bento/index.ts
@@ -1,0 +1,1 @@
+export * from "./bento-grid"


### PR DESCRIPTION
## Summary
- add horizontal bento grid components
- add demo page using sidebar navigation

## Testing
- `npx next lint` *(fails: could not install deps)*

------
https://chatgpt.com/codex/tasks/task_e_684247b755308329835968b5d45ff5a7